### PR TITLE
Add jsdoc linter plugin + rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,11 +1,50 @@
 module.exports = {
     parser: '@typescript-eslint/parser',
-    plugins: ['@typescript-eslint'],
+    plugins: ['@typescript-eslint', 'jsdoc'],
     extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
     parserOptions: {
         project: './tsconfig.base.json',
     },
     rules: {
         '@typescript-eslint/no-explicit-any': 'off',
+        'jsdoc/check-access': 1, // Recommended
+        'jsdoc/check-alignment': 1, // Recommended
+        'jsdoc/check-indentation': 1,
+        'jsdoc/check-line-alignment': 1,
+        'jsdoc/check-param-names': 1, // Recommended
+        'jsdoc/check-property-names': 1, // Recommended
+        'jsdoc/check-syntax': 1,
+        'jsdoc/check-types': 1, // Recommended
+        'jsdoc/check-values': 1, // Recommended
+        'jsdoc/empty-tags': 1, // Recommended
+        'jsdoc/implements-on-classes': 1, // Recommended
+        'jsdoc/informative-docs': 1,
+        'jsdoc/match-description': 1,
+        'jsdoc/multiline-blocks': 1, // Recommended
+        'jsdoc/no-bad-blocks': 1,
+        'jsdoc/no-blank-block-descriptions': 1,
+        'jsdoc/no-defaults': 1,
+        'jsdoc/no-multi-asterisks': 1, // Recommended
+        'jsdoc/no-types': 1,
+        'jsdoc/no-undefined-types': 1, // Recommended
+        'jsdoc/require-asterisk-prefix': 1,
+        'jsdoc/require-description': 1,
+        'jsdoc/require-description-complete-sentence': 1,
+        'jsdoc/require-hyphen-before-param-description': 1,
+        'jsdoc/require-jsdoc': 1, // Recommended
+        'jsdoc/require-param': 1, // Recommended
+        'jsdoc/require-param-description': 1, // Recommended
+        'jsdoc/require-param-name': 1, // Recommended
+        'jsdoc/require-property': 1, // Recommended
+        'jsdoc/require-property-description': 1, // Recommended
+        'jsdoc/require-property-name': 1, // Recommended
+        'jsdoc/require-property-type': 1, // Recommended
+        'jsdoc/require-returns': 1, // Recommended
+        'jsdoc/require-returns-check': 1, // Recommended
+        'jsdoc/require-returns-description': 1, // Recommended
+        'jsdoc/require-throws': 1,
+        'jsdoc/require-yields': 1, // Recommended
+        'jsdoc/require-yields-check': 1, // Recommended
+        'jsdoc/valid-types': 1, // Recommended
     },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
                 "eslint": "^8.57.0",
                 "eslint-config-airbnb-typescript": "^18.0.0",
                 "eslint-config-prettier": "^9.1.0",
+                "eslint-plugin-jsdoc": "^48.2.5",
                 "husky": "^9.0.11",
                 "lint-staged": "^15.2.2",
                 "mocha": "10.0.0",
@@ -185,6 +186,23 @@
             "version": "0.0.1-alpha.1",
             "resolved": "https://registry.npmjs.org/@brandonblack/musig/-/musig-0.0.1-alpha.1.tgz",
             "integrity": "sha512-00RbByQG85lSzrkDjCblzrUc2n1LJAPPrEMHS4oMg+QckE0kzjd26JytT6yx6tNU2+aOXfK7O4kGW/sKVL67cw=="
+        },
+        "node_modules/@es-joy/jsdoccomment": {
+            "version": "0.43.0",
+            "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.43.0.tgz",
+            "integrity": "sha512-Q1CnsQrytI3TlCB1IVWXWeqUIPGVEKGaE7IbVdt13Nq/3i0JESAkQQERrfiQkmlpijl+++qyqPgaS31Bvc1jRQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/eslint": "^8.56.5",
+                "@types/estree": "^1.0.5",
+                "@typescript-eslint/types": "^7.2.0",
+                "comment-parser": "1.4.1",
+                "esquery": "^1.5.0",
+                "jsdoc-type-pratt-parser": "~4.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
         },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.4.0",
@@ -511,6 +529,16 @@
             "dev": true,
             "dependencies": {
                 "@types/ms": "*"
+            }
+        },
+        "node_modules/@types/eslint": {
+            "version": "8.56.10",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
+            "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "*",
+                "@types/json-schema": "*"
             }
         },
         "node_modules/@types/estree": {
@@ -1008,6 +1036,15 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/are-docs-informative": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+            "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+            "dev": true,
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/argparse": {
@@ -2213,6 +2250,41 @@
             "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/eslint-plugin-jsdoc": {
+            "version": "48.2.5",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-48.2.5.tgz",
+            "integrity": "sha512-ZeTfKV474W1N9niWfawpwsXGu+ZoMXu4417eBROX31d7ZuOk8zyG66SO77DpJ2+A9Wa2scw/jRqBPnnQo7VbcQ==",
+            "dev": true,
+            "dependencies": {
+                "@es-joy/jsdoccomment": "~0.43.0",
+                "are-docs-informative": "^0.0.2",
+                "comment-parser": "1.4.1",
+                "debug": "^4.3.4",
+                "escape-string-regexp": "^4.0.0",
+                "esquery": "^1.5.0",
+                "is-builtin-module": "^3.2.1",
+                "semver": "^7.6.1",
+                "spdx-expression-parse": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/eslint-scope": {
@@ -3500,6 +3572,15 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/jsdoc-type-pratt-parser": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
+            "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/json-buffer": {
@@ -5419,6 +5500,28 @@
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
             }
+        },
+        "node_modules/spdx-exceptions": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+            "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+            "dev": true
+        },
+        "node_modules/spdx-expression-parse": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+            "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+            "dev": true,
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-license-ids": {
+            "version": "3.0.17",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
+            "integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==",
+            "dev": true
         },
         "node_modules/stack-utils": {
             "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "eslint": "^8.57.0",
         "eslint-config-airbnb-typescript": "^18.0.0",
         "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-jsdoc": "^48.2.5",
         "husky": "^9.0.11",
         "lint-staged": "^15.2.2",
         "mocha": "10.0.0",


### PR DESCRIPTION
- Add `eslint-plugin-jsdoc` to enforce JSDoc syntax during lint
- Configure plugin rules