### PR TITLE
Revert wordlist and ts-ignore change

### DIFF
--- a/src.ts/providers/provider.ts
+++ b/src.ts/providers/provider.ts
@@ -1547,6 +1547,8 @@ export class QuaiTransactionResponse implements QuaiTransactionLike, QuaiTransac
      */
     readonly accessList!: null | AccessList;
 
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     #startBlock: number;
 
     /**

--- a/src.ts/wordlists/decode-owl.ts
+++ b/src.ts/wordlists/decode-owl.ts
@@ -32,7 +32,8 @@ export function decode(data: string, subs: string): Array<string> {
 
     // Get all tle clumps; each suffix, first-increment and second-increment
     const clumps: Array<string> = [];
-    const leftover = data.replace(/(:|([0-9])|([A-Z][a-z]*))/g, (item, semi) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const leftover = data.replace(/(:|([0-9])|([A-Z][a-z]*))/g, (all, item, semi, word) => {
         if (semi) {
             for (let i = parseInt(semi); i >= 0; i--) {
                 clumps.push(';');


### PR DESCRIPTION
- Fix issue with `@ts-ignore` and `#startBlock` var that was causing compile/build to fail
- Fix wordlist bug