### PR TITLE
Pre-push build

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,2 @@
+# add test run on pre-push here when tests are working `npm run test`
+npm run build

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
         }
     },
     "lint-staged": {
-        "src.ts/**/*.{ts}": [
+        "src.ts/**/*.ts": [
             "eslint --fix",
             "prettier --write"
         ]

--- a/src.ts/providers/provider.ts
+++ b/src.ts/providers/provider.ts
@@ -2027,6 +2027,8 @@ export class QiTransactionResponse implements QiTransactionLike, QiTransactionRe
 
     readonly txOutputs?: Array<TxOutput>;
 
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     #startBlock: number;
     /**
      * @ignore


### PR DESCRIPTION
- Fix duplicate `@ts-ignore` error that was causing
- Fix `eslint` bracket warning in `lint-staged` command
- Add husky pre-push build to catch build failures before pushing