### PR TITLE
Add link formatter plugin

### DIFF
--- a/docs/plugins/typedoc-plugin-link-formatter.mjs
+++ b/docs/plugins/typedoc-plugin-link-formatter.mjs
@@ -8,21 +8,17 @@ import { MarkdownPageEvent } from 'typedoc-plugin-markdown';
  */
 export function load(app) {
     app.renderer.on(
-        MarkdownPageEvent.BEGIN,
+        MarkdownPageEvent.END,
         /**
          * @param {import('typedoc-plugin-markdown').MarkdownPageEvent} page
          */
         (page) => {
-            let summary = '';
-            if (page.model?.comment?.summary) {
-                summary = page.model.comment.summary[0].text + '...';
-                summary = summary.replace(/\n/g, ' ');
+            if (page.contents) {
+                if (page.contents.includes('.mdx')) {
+                  const regex = /(\.mdx)/g;
+                  page.contents = page.contents.replace(regex, '');
+                }
             }
-            page.frontmatter = {
-                title: page.model?.name,
-                description: summary,
-                ...page.frontmatter,
-            };
         },
     );
 }

--- a/docs/plugins/typedoc-plugin-mintlify-frontmatter.mjs
+++ b/docs/plugins/typedoc-plugin-mintlify-frontmatter.mjs
@@ -13,14 +13,8 @@ export function load(app) {
          * @param {import('typedoc-plugin-markdown').MarkdownPageEvent} page
          */
         (page) => {
-            let summary = '';
-            if (page.model?.comment?.summary) {
-                summary = page.model.comment.summary[0].text + '...';
-                summary = summary.replace(/\n/g, ' ');
-            }
             page.frontmatter = {
                 title: page.model?.name,
-                description: summary,
                 ...page.frontmatter,
             };
         },

--- a/docs/plugins/typedoc-plugin-navigation-output.mjs
+++ b/docs/plugins/typedoc-plugin-navigation-output.mjs
@@ -1,22 +1,22 @@
 // @ts-check
-import fs from 'fs'
+import fs from 'fs';
 
 /**
- *  This plugin parses and generates a navigation file for the documentation
- *  that complies with Mintlify's navigation format.
+ * This plugin parses and generates a navigation file for the documentation that complies with Mintlify's navigation
+ * format.
  *
- *  @param {import('typedoc-plugin-markdown').MarkdownApplication} app
+ * @param {import('typedoc-plugin-markdown').MarkdownApplication} app
  */
 export function load(app) {
-	app.renderer.postRenderAsyncJobs.push(async (renderer) => {
-		const navigation = renderer.navigation
-		if (!navigation) {
-			return
-		}
-		const formattedNavigation = navigation.map((group) => ({
-			group: group.title,
-			pages: (group.children || []).map((child) => `content/${child.url.replace('.mdx', '')}`),
-		}))
-		fs.writeFileSync('./docs/content/navigation.json', JSON.stringify(formattedNavigation, null, 2))
-	})
+    app.renderer.postRenderAsyncJobs.push(async (renderer) => {
+        const navigation = renderer.navigation;
+        if (!navigation) {
+            return;
+        }
+        const formattedNavigation = navigation.map((group) => ({
+            group: group.title,
+            pages: (group.children || []).map((child) => `content/${child.url.replace('.mdx', '')}`),
+        }));
+        fs.writeFileSync('./docs/content/navigation.json', JSON.stringify(formattedNavigation, null, 2));
+    });
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,37 +1,38 @@
 {
-	// base config
-	"out": "docs/content",
-	"tsconfig": "tsconfig.base.json",
-	"entryPoints": ["./src/quais.ts"],
+    // base config
+    "out": "docs/content",
+    "tsconfig": "tsconfig.base.json",
+    "entryPoints": ["./src/quais.ts"],
 
-	// specific inclusions and exclusions
-	"excludeProtected": true,
-	"excludeNotDocumented": true,
-	"exclude": ["./src/_admin/**/*", "./src/_tests/**/*", "./src/testcases/**/*"],
+    // specific inclusions and exclusions
+    "excludeProtected": true,
+    "excludeNotDocumented": true,
+    "exclude": ["./src/_admin/**/*", "./src/_tests/**/*", "./src/testcases/**/*"],
 
-	// plugins
-	"plugin": [
-		"typedoc-plugin-remove-references", // remove additional references that clutter documentation
-		"typedoc-plugin-markdown", // generate markdown files
-		"typedoc-plugin-frontmatter", // add frontmatter to markdown files, prereq for the below custom plugin
-		"./docs/plugins/typedoc-plugin-mintlify-frontmatter.mjs", // formats frontmatter to match mintlify
-		"./docs/plugins/typedoc-plugin-navigation-output.mjs" // formats navigation to match mintlify
-	],
+    // plugins
+    "plugin": [
+        "typedoc-plugin-remove-references", // remove additional references that clutter documentation
+        "typedoc-plugin-markdown", // generate markdown files
+        "typedoc-plugin-frontmatter", // add frontmatter to markdown files, prereq for the below custom plugin
+        "./docs/plugins/typedoc-plugin-mintlify-frontmatter.mjs", // formats frontmatter to match mintlify
+        "./docs/plugins/typedoc-plugin-navigation-output.mjs", // formats navigation to match mintlify
+        "./docs/plugins/typedoc-plugin-link-formatter.mjs" // removes ".mdx" from links
+    ],
 
-	// formatting + mintlify compatibility
-	"fileExtension": ".mdx", // use mdx files for mintlfiy compatibility
-	"entryFileName": "index.mdx", // rename entry from "README.md" to "index.mdx"
-	"mergeReadme": true, // merge README.md into index.mdx
-	"hidePageHeader": true, // hide page header, conflicts with mintlify
-	"hidePageTitle": true, // hide page title, conflicts with mintlify
-	"hideBreadcrumbs": true, // hide breadcrumbs, conflicts with mintlify
-	"useCodeBlocks": true, // makes API definitions more readable
-	"expandObjects": true,
-	"parametersFormat": "table", // readability
-	"propertiesFormat": "table", // readability
-	"publicPath": "/content/", // format links for mintlify
-	"navigation": {
-		"includeCategories": true,
-		"includeGroups": false
-	}
+    // formatting + mintlify compatibility
+    "fileExtension": ".mdx", // use mdx files for mintlfiy compatibility
+    "entryFileName": "index.mdx", // rename entry from "README.md" to "index.mdx"
+    "mergeReadme": true, // merge README.md into index.mdx
+    "hidePageHeader": true, // hide page header, conflicts with mintlify
+    "hidePageTitle": true, // hide page title, conflicts with mintlify
+    "hideBreadcrumbs": true, // hide breadcrumbs, conflicts with mintlify
+    "useCodeBlocks": true, // makes API definitions more readable
+    "expandObjects": true,
+    "parametersFormat": "table", // readability
+    "propertiesFormat": "table", // readability
+    "publicPath": "/content/", // format links for mintlify
+    "navigation": {
+        "includeCategories": true,
+        "includeGroups": false
+    }
 }


### PR DESCRIPTION
- Add custom plugin `typedoc-plugin-link-formatter`
  - Removes the `.mdx` extension at the end of all of the converted links in doc markdown output
  - Ensures that all links route correctly in Mintlify
- Format plugin files
- Add plugin to `typedoc.json`