### PR TITLE
Wallet improvements

### DIFF
--- a/src/wallet/hdnodewallet.ts
+++ b/src/wallet/hdnodewallet.ts
@@ -249,13 +249,21 @@ export class HDNodeWallet extends BaseWallet {
         //   - Mainnet: public=0x0488B21E, private=0x0488ADE4
         //   - Testnet: public=0x043587CF, private=0x04358394
 
-        assert(this.depth < 256, "Depth too deep", "UNSUPPORTED_OPERATION", { operation: "extendedKey" });
+        assert(this.depth < 256, 'Depth too deep', 'UNSUPPORTED_OPERATION', {
+            operation: 'extendedKey',
+        });
 
-        return encodeBase58Check(concat([
-            "0x0488ADE4", zpad(this.depth, 1), this.parentFingerprint,
-            zpad(this.index, 4), this.chainCode,
-            concat([ "0x00", this.privateKey ])
-        ]));
+        const myKey = encodeBase58Check(
+            concat([
+                '0x0488ADE4',
+                '0x' + zpad(this.depth, 2),
+                this.parentFingerprint ?? '',
+                '0x' + zpad(this.index, 4),
+                this.chainCode,
+                concat(['0x00', this.privateKey]),
+            ]),
+        );
+        return myKey;
     }
 
     /**

--- a/src/wallet/hdwallet.ts
+++ b/src/wallet/hdwallet.ts
@@ -19,8 +19,8 @@ export interface NeuteredAddressInfo {
 // Constant to represent the maximum attempt to derive an address
 const MAX_ADDRESS_DERIVATION_ATTEMPTS = 10000000;
 
-export abstract class HDWallet {
-    protected static _coinType?: number = 969 || 994;
+export abstract class AbstractHDWallet {
+	protected static _coinType?: number = 969 || 994;
 
     // Map of account number to HDNodeWallet
     protected _accounts: Map<number, HDNodeWallet> = new Map();
@@ -46,7 +46,7 @@ export abstract class HDWallet {
 	}
 	
 	protected coinType(): number {
-		return (this.constructor as typeof HDWallet)._coinType!;
+		return (this.constructor as typeof AbstractHDWallet)._coinType!;
 	}
 
     // helper methods that adds an account HD node to the HD wallet following the BIP-44 standard.
@@ -167,12 +167,13 @@ export abstract class HDWallet {
         return Array.from(addresses).filter((addressInfo) => addressInfo.zone === zone);
     }
 
-	protected static createInstance<T extends HDWallet>(this: new (root: HDNodeWallet) => T, mnemonic: Mnemonic): T {
+	protected static createInstance<T extends AbstractHDWallet>(this: new (root: HDNodeWallet) => T, mnemonic: Mnemonic): T {
         const coinType = (this as any)._coinType;
 		const root = HDNodeWallet.fromMnemonic(mnemonic, (this as any).parentPath(coinType));
 		return new this(root);
 	}
 
+<<<<<<< HEAD
     static fromMnemonic<T extends HDWallet>(this: new (root: HDNodeWallet) => T, mnemonic: Mnemonic): T {
         return (this as any).createInstance(mnemonic);
     }
@@ -207,6 +208,25 @@ export abstract class HDWallet {
         const mnemonic = Mnemonic.fromPhrase(phrase, password, wordlist);
         return (this as any).createInstance(mnemonic);
     }
+=======
+	static fromMnemonic<T extends AbstractHDWallet>(this: new (root: HDNodeWallet) => T, mnemonic: Mnemonic): T {
+		return (this as any).createInstance(mnemonic);
+	}
+
+	static createRandom<T extends AbstractHDWallet>(this: new (root: HDNodeWallet) => T, password?: string, wordlist?: Wordlist): T {
+		if (password == null) { password = ""; }
+		if (wordlist == null) { wordlist = LangEn.wordlist(); }
+		const mnemonic = Mnemonic.fromEntropy(randomBytes(16), password, wordlist);
+		return (this as any).createInstance(mnemonic);
+	}
+
+	static fromPhrase<T extends AbstractHDWallet>(this: new (root: HDNodeWallet) => T, phrase: string, password?: string, wordlist?: Wordlist): T {
+		if (password == null) { password = ""; }
+		if (wordlist == null) { wordlist = LangEn.wordlist(); }
+		const mnemonic = Mnemonic.fromPhrase(phrase, password, wordlist);
+		return (this as any).createInstance(mnemonic);
+	}
+>>>>>>> e0d7b0d3 (rename HDWallt to AbstractHDWallet)
 
     abstract signTransaction(tx: TransactionRequest): Promise<string>;
 

--- a/src/wallet/hdwallet.ts
+++ b/src/wallet/hdwallet.ts
@@ -31,10 +31,7 @@ export abstract class HDWallet {
     // Root node of the HD wallet
     protected _root: HDNodeWallet;
 
-    // Wallet parent path
-    protected static _parentPath: string = '';
-
-    protected provider?: Provider;
+	protected provider?: Provider;
 
     /**
      * @private
@@ -44,13 +41,13 @@ export abstract class HDWallet {
         this.provider = provider;
     }
 
-    protected parentPath(): string {
-        return (this.constructor as typeof HDWallet)._parentPath;
-    }
-
-    protected coinType(): number {
-        return (this.constructor as typeof HDWallet)._coinType!;
-    }
+    protected static parentPath(coinType: number): string {
+		return `m/44'/${coinType}'`;
+	}
+	
+	protected coinType(): number {
+		return (this.constructor as typeof HDWallet)._coinType!;
+	}
 
     // helper methods that adds an account HD node to the HD wallet following the BIP-44 standard.
     protected addAccount(accountIndex: number): void {
@@ -170,10 +167,11 @@ export abstract class HDWallet {
         return Array.from(addresses).filter((addressInfo) => addressInfo.zone === zone);
     }
 
-    protected static createInstance<T extends HDWallet>(this: new (root: HDNodeWallet) => T, mnemonic: Mnemonic): T {
-        const root = HDNodeWallet.fromMnemonic(mnemonic, (this as any)._parentPath);
-        return new this(root);
-    }
+	protected static createInstance<T extends HDWallet>(this: new (root: HDNodeWallet) => T, mnemonic: Mnemonic): T {
+        const coinType = (this as any)._coinType;
+		const root = HDNodeWallet.fromMnemonic(mnemonic, (this as any).parentPath(coinType));
+		return new this(root);
+	}
 
     static fromMnemonic<T extends HDWallet>(this: new (root: HDNodeWallet) => T, mnemonic: Mnemonic): T {
         return (this as any).createInstance(mnemonic);

--- a/src/wallet/hdwallet.ts
+++ b/src/wallet/hdwallet.ts
@@ -77,14 +77,14 @@ export abstract class AbstractHDWallet {
 			addrIndex++;
 			// put a hard limit on the number of addresses to derive
 			if (addrIndex - startingIndex > MAX_ADDRESS_DERIVATION_ATTEMPTS) {
-				throw new Error(`Failed to derive a valid address for the zone ${zone} after MAX_ADDRESS_DERIVATION_ATTEMPTS attempts.`);
+				throw new Error(`Failed to derive a valid address for the zone ${zone} after ${MAX_ADDRESS_DERIVATION_ATTEMPTS} attempts.`);
 			}
 		} while (!isValidAddressForZone(addressNode.address));
 
         return addressNode;
     }
 
-    addAddress(account: number, addressIndex: number, zone: Zone): NeuteredAddressInfo {
+    public addAddress(account: number, addressIndex: number, zone: Zone): NeuteredAddressInfo {
         if (!this._accounts.has(account)) {
             this.addAccount(account);
         }
@@ -111,7 +111,7 @@ export abstract class AbstractHDWallet {
 
         return neuteredAddressInfo;
     }
-	getNextAddress(accountIndex: number, zone: Zone): NeuteredAddressInfo {
+	public getNextAddress(accountIndex: number, zone: Zone): NeuteredAddressInfo {
         this.validateZone(zone);
         if (!this._accounts.has(accountIndex)) {
             this.addAccount(accountIndex);
@@ -140,7 +140,7 @@ export abstract class AbstractHDWallet {
         return neuteredAddressInfo;
     }
 
-    getAddressInfo(address: string): NeuteredAddressInfo | null {
+    public getAddressInfo(address: string): NeuteredAddressInfo | null {
         const addressInfo = this._addresses.get(address);
         if (!addressInfo) {
             return null;
@@ -148,12 +148,12 @@ export abstract class AbstractHDWallet {
         return addressInfo;
     }
 
-    getAddressesForAccount(account: number): NeuteredAddressInfo[] {
+    public getAddressesForAccount(account: number): NeuteredAddressInfo[] {
         const addresses = this._addresses.values();
         return Array.from(addresses).filter((addressInfo) => addressInfo.account === account);
     }
 
-	getAddressesForZone(zone: Zone): NeuteredAddressInfo[] {
+	public getAddressesForZone(zone: Zone): NeuteredAddressInfo[] {
         this.validateZone(zone);
 		const addresses = this._addresses.values();
 		return Array.from(addresses).filter((addressInfo) => addressInfo.zone === zone);
@@ -187,7 +187,7 @@ export abstract class AbstractHDWallet {
 
     abstract sendTransaction(tx: TransactionRequest): Promise<TransactionResponse>;
 
-    connect(provider: Provider): void {
+    public connect(provider: Provider): void {
         this.provider = provider;
     }
 

--- a/src/wallet/qi-hdwallet.ts
+++ b/src/wallet/qi-hdwallet.ts
@@ -42,7 +42,7 @@ export class QiHDWallet extends AbstractHDWallet {
         super(root, provider);
     }
 
-	getNextChangeAddress(account: number, zone: Zone): NeuteredAddressInfo {
+	public getNextChangeAddress(account: number, zone: Zone): NeuteredAddressInfo {
 		this.validateZone(zone);
 		if (!this._accounts.has(account)) {
 			this.addAccount(account);
@@ -68,7 +68,7 @@ export class QiHDWallet extends AbstractHDWallet {
         return neuteredAddressInfo;
     }
 
-	importOutpoints(outpoints: OutpointInfo[]): void {
+	public importOutpoints(outpoints: OutpointInfo[]): void {
         outpoints.forEach((outpoint) => {
             this.validateZone(outpoint.zone);
             this._outpoints.push(outpoint);
@@ -76,23 +76,23 @@ export class QiHDWallet extends AbstractHDWallet {
 		
 	}
 
-	getOutpoints(zone: Zone): OutpointInfo[] {
+	public getOutpoints(zone: Zone): OutpointInfo[] {
 		this.validateZone(zone);
 		return this._outpoints.filter((outpoint) => outpoint.zone === zone);
 	}
 
-    /**
-     * Signs a Qi transaction and returns the serialized transaction
-     *
-     * @param {QiTransactionRequest} tx - The transaction to sign.
-     *
-     * @returns {Promise<string>} The serialized transaction.
-     * @throws {Error} If the UTXO transaction is invalid.
-     */
-    async signTransaction(tx: QiTransactionRequest): Promise<string> {
-        const txobj = QiTransaction.from(<TransactionLike>tx);
-        if (!txobj.txInputs || txobj.txInputs.length == 0 || !txobj.txOutputs)
-            throw new Error('Invalid UTXO transaction, missing inputs or outputs');
+	/**
+	 * Signs a Qi transaction and returns the serialized transaction
+	 *
+	 * @param {QiTransactionRequest} tx - The transaction to sign.
+	 *
+	 * @returns {Promise<string>} The serialized transaction.
+	 * @throws {Error} If the UTXO transaction is invalid.
+	 */
+	public async signTransaction(tx: QiTransactionRequest): Promise<string> {
+		const txobj = QiTransaction.from(<TransactionLike>tx);
+		if (!txobj.txInputs || txobj.txInputs.length == 0 || !txobj.txOutputs)
+			throw new Error('Invalid UTXO transaction, missing inputs or outputs');
 
         const hash = keccak_256(txobj.unsignedSerialized);
 
@@ -108,19 +108,19 @@ export class QiHDWallet extends AbstractHDWallet {
         return txobj.serialized;
     }
 
-    async sendTransaction(tx: QiTransactionRequest): Promise<TransactionResponse> {
-        if (!this.provider) {
-            throw new Error('Provider is not set');
-        }
-        if (!tx.inputs || tx.inputs.length === 0) {
-            throw new Error('Transaction has no inputs');
-        }
-        const input = tx.inputs[0];
-        const address = computeAddress(hexlify(input.pub_key));
-        const shard = getZoneForAddress(address);
-        if (!shard) {
-            throw new Error(`Address ${address} not found in any shard`);
-        }
+	public async sendTransaction(tx: QiTransactionRequest): Promise<TransactionResponse> {
+		if (!this.provider) {
+            throw new Error("Provider is not set");
+		}
+		if (!tx.inputs || tx.inputs.length === 0) {
+			throw new Error('Transaction has no inputs');
+		}
+		const input = tx.inputs[0];
+		const address = computeAddress(hexlify(input.pub_key));
+		const shard = getZoneForAddress(address);
+		if (!shard) {
+			throw new Error(`Address ${address} not found in any shard`);
+		}
 
         // verify all inputs are from the same shard
         if (tx.inputs.some((input) => getZoneForAddress(computeAddress(hexlify(input.pub_key))) !== shard)) {
@@ -200,7 +200,7 @@ export class QiHDWallet extends AbstractHDWallet {
 	// scan scans the specified zone for addresses with unspent outputs.
 	// Starting at index 0, tt will generate new addresses until
 	// the gap limit is reached for both gap and change addresses.
-	async scan(zone: Zone, account: number = 0): Promise<void> { 
+	public async scan(zone: Zone, account: number = 0): Promise<void> { 
 		this.validateZone(zone);
 		// flush the existing addresses and outpoints
 		this._addresses = new Map();
@@ -216,7 +216,7 @@ export class QiHDWallet extends AbstractHDWallet {
 	// Starting at the last address index, it will generate new addresses until
 	// the gap limit is reached for both gap and change addresses.
 	// If no account is specified, it will scan all accounts known to the wallet
-	async sync(zone: Zone, account?: number): Promise<void> { 
+	public async sync(zone: Zone, account?: number): Promise<void> { 
 		this.validateZone(zone);
 		if (account) {
 			await this._scan(zone, account);
@@ -285,7 +285,7 @@ export class QiHDWallet extends AbstractHDWallet {
 	
 	
 	// getOutpointsByAddress queries the network node for the outpoints of the specified address
-    private async getOutpointsByAddress(address: string): Promise<Outpoint[]> {
+	private async getOutpointsByAddress(address: string): Promise<Outpoint[]> {
         try {
             const outpointsMap = await this.provider!.getOutpointsByAddress(address);
             if (!outpointsMap) {
@@ -297,19 +297,19 @@ export class QiHDWallet extends AbstractHDWallet {
         }
     }
 
-	getChangeAddressesForZone(zone: Zone): NeuteredAddressInfo[] {
+	public getChangeAddressesForZone(zone: Zone): NeuteredAddressInfo[] {
 		this.validateZone(zone);
 		const changeAddresses = this._changeAddresses.values();
 		return Array.from(changeAddresses).filter((addressInfo) => addressInfo.zone === zone);
 	}
 
-	getGapAddressesForZone(zone: Zone): NeuteredAddressInfo[] {
+	public getGapAddressesForZone(zone: Zone): NeuteredAddressInfo[] {
 		this.validateZone(zone);
 		const gapAddresses = this._gapAddresses.filter((addressInfo) => addressInfo.zone === zone);
 		return gapAddresses;
 	}
 
-	getGapChangeAddressesForZone(zone: Zone): NeuteredAddressInfo[] {
+	public getGapChangeAddressesForZone(zone: Zone): NeuteredAddressInfo[] {
 		this.validateZone(zone);
 		const gapChangeAddresses = this._gapChangeAddresses.filter((addressInfo) => addressInfo.zone === zone);
 		return gapChangeAddresses;

--- a/src/wallet/qi-hdwallet.ts
+++ b/src/wallet/qi-hdwallet.ts
@@ -1,5 +1,7 @@
-import { HDWallet, NeuteredAddressInfo } from './hdwallet.js';
-import { HDNodeWallet } from './hdnodewallet.js';
+
+
+import { AbstractHDWallet, NeuteredAddressInfo } from './hdwallet';
+import { HDNodeWallet } from "./hdnodewallet";
 import { QiTransactionRequest, Provider, TransactionResponse } from '../providers/index.js';
 import { computeAddress } from '../address/index.js';
 import { getBytes, hexlify } from '../utils/index.js';
@@ -18,8 +20,7 @@ type OutpointInfo = {
     account?: number;
 };
 
-export class QiHDWallet extends HDWallet {
-    protected static _GAP_LIMIT: number = 20;
+export class QiHDWallet extends AbstractHDWallet {
 
     protected static _cointype: number = 969;
 

--- a/src/wallet/qi-hdwallet.ts
+++ b/src/wallet/qi-hdwallet.ts
@@ -23,13 +23,8 @@ export class QiHDWallet extends HDWallet {
 
     protected static _cointype: number = 969;
 
-    protected static _parentPath = `m/44'/${this._cointype}'`;
-
-    // Map of change addresses to address info
-    protected _changeAddresses: Map<string, NeuteredAddressInfo> = new Map();
-
-    // Array of naked addresses
-    protected _nakedChangeAddresses: NeuteredAddressInfo[] = [];
+	// Map of change addresses to address info
+	protected _changeAddresses: Map<string, NeuteredAddressInfo> = new Map();
 
     // Array of naked change addresses
     protected _nakedAddresses: NeuteredAddressInfo[] = [];

--- a/src/wallet/quai-hdwallet.ts
+++ b/src/wallet/quai-hdwallet.ts
@@ -1,9 +1,10 @@
-import { HDWallet } from './hdwallet.js';
-import { HDNodeWallet } from './hdnodewallet.js';
+
+import { AbstractHDWallet } from './hdwallet';
+import { HDNodeWallet } from "./hdnodewallet";
 import { QuaiTransactionRequest, Provider, TransactionResponse } from '../providers/index.js';
 import { resolveAddress } from '../address/index.js';
 
-export class QuaiHDWallet extends HDWallet {
+export class QuaiHDWallet extends AbstractHDWallet {
     protected static _cointype: number = 994;
 
     private constructor(root: HDNodeWallet, provider?: Provider) {

--- a/src/wallet/quai-hdwallet.ts
+++ b/src/wallet/quai-hdwallet.ts
@@ -26,14 +26,14 @@ export class QuaiHDWallet extends AbstractHDWallet {
         return changeNode.deriveChild(fromAddressInfo.index);
     }
 
-    async signTransaction(tx: QuaiTransactionRequest): Promise<string> {
+    public async signTransaction(tx: QuaiTransactionRequest): Promise<string> {
         const from = await resolveAddress(tx.from);
         const fromNode = this._getHDNode(from);
         const signedTx = await fromNode.signTransaction(tx);
         return signedTx;
     }
 
-    async sendTransaction(tx: QuaiTransactionRequest): Promise<TransactionResponse> {
+    public async sendTransaction(tx: QuaiTransactionRequest): Promise<TransactionResponse> { 
         if (!this.provider) {
             throw new Error('Provider is not set');
         }

--- a/src/wallet/quai-hdwallet.ts
+++ b/src/wallet/quai-hdwallet.ts
@@ -6,8 +6,6 @@ import { resolveAddress } from '../address/index.js';
 export class QuaiHDWallet extends HDWallet {
     protected static _cointype: number = 994;
 
-    protected static _parentPath = `m/44'/${this._cointype}'`;
-
     private constructor(root: HDNodeWallet, provider?: Provider) {
         super(root, provider);
     }


### PR DESCRIPTION
Improvements to Qi and Quai HD wallets:

- Rename class to AbstractHDWallet
- Semantic change in order of inputs to the addAddress method (account, addressIndex, zone)
- Update validateZone method to use Enum zone byte
- Replace "naked" address term with "gap"
- Add the public modifier to all public methods
- Remove the _parentPath variable in favor of calculating it in the parentPath