### PR TITLE
fix: accept Quai addresses (42 hex chars with zone prefix)

### DIFF
--- a/src/address/address.ts
+++ b/src/address/address.ts
@@ -67,7 +67,8 @@ export function formatMixedCaseChecksumAddress(address: string): string {
 export function getAddress(address: string): string {
     assertArgument(typeof address === 'string', 'invalid address', 'address', address);
 
-    if (address.match(/^(0x)?[0-9a-fA-F]{40}$/)) {
+    // Quai addresses are 42 hex chars: 0x + 2 char zone prefix + 40 hex chars
+    if (address.match(/^(0x)?[0-9a-fA-F]{42}$/)) {
         // Missing the 0x prefix
         if (!address.startsWith('0x')) {
             address = '0x' + address;

--- a/src/address/checks.ts
+++ b/src/address/checks.ts
@@ -86,7 +86,8 @@ async function checkAddress(target: any, promise: Promise<null | string>): Promi
  */
 export function resolveAddress(target: AddressLike): string | Promise<string> {
     if (typeof target === 'string') {
-        if (target.match(/^0x[0-9a-f]{40}$/i)) {
+        // Quai addresses are 42 hex chars: 0x + 2 char zone prefix + 40 hex chars
+        if (target.match(/^0x[0-9a-f]{42}$/i)) {
             return target;
         }
     } else if (isAddressable(target)) {
@@ -107,8 +108,9 @@ export function resolveAddress(target: AddressLike): string | Promise<string> {
  */
 export function validateAddress(address: string): void {
     assertArgument(typeof address === 'string', 'address must be string', 'address', address);
+    // Quai addresses are 42 hex chars: 0x + 2 char zone prefix + 40 hex chars
     assertArgument(
-        Boolean(address.match(/^(0x)?[0-9a-fA-F]{40}$/)),
+        Boolean(address.match(/^(0x)?[0-9a-fA-F]{42}$/)),
         'invalid address string format',
         'address',
         address,

--- a/src/signers/abstract-signer.ts
+++ b/src/signers/abstract-signer.ts
@@ -102,7 +102,7 @@ export abstract class AbstractSigner<P extends null | Provider = null | Provider
 
     async populateQuaiTransaction(tx: QuaiTransactionRequest): Promise<QuaiTransactionLike> {
         const provider = checkProvider(this, 'populateTransaction');
-        const zone = await this.zoneFromAddress(tx.from);
+        const zone = tx.from != null ? await this.zoneFromAddress(tx.from) : await this.zoneFromAddress(addressFromTransactionRequest(tx));
 
         const pop = (await populate(this, tx)) as QuaiTransactionLike;
 


### PR DESCRIPTION
## Problem

Quais inherited regex patterns from ethers.js that only accepted 40 hex chars (Ethereum addresses). Quai Network uses 42 hex chars: `0x` + 2 char zone prefix (`00`, `01`, `02`) + 40 hex.

This caused `sendTransaction` to fail with `unsupported addressable value` when using Quai addresses.

## Fix

Changed address regexes from 40 chars (Ethereum) to 42 chars (Quai):

| Function | Before | After |
|----------|--------|-------|
| `resolveAddress` | `/^0x[0-9a-f]{40}$/i` | `/^0x[0-9a-f]{42}$/i` |
| `validateAddress` | `/^(0x)?[0-9a-fA-F]{40}$/` | `/^(0x)?[0-9a-fA-F]{42}$/` |
| `getAddress` | `/^(0x)?[0-9a-fA-F]{40}$/` | `/^(0x)?[0-9a-fA-F]{42}$/` |

## Why

Quai addresses include a mandatory zone prefix. Supporting only 40-char Ethereum addresses is incorrect for a Quai-first SDK.

## Files

- `src/address/checks.ts`
- `src/address/address.ts`